### PR TITLE
Cant use HighVoltage::RouteDrawers::Root

### DIFF
--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -1,6 +1,6 @@
 = nav_bar brand: 'Experience', brand_link: root_path do
   = menu_group do
-    = menu_item 'Home', root_path
+    = menu_item 'Home', page_path('home')
     = menu_item 'About', page_path('about')
   = menu_group pull: :right do
-    = menu_item 'Sign Up', root_path
+    = menu_item 'Sign Up', page_path

--- a/app/views/pages/about.haml
+++ b/app/views/pages/about.haml
@@ -1,0 +1,6 @@
+- content_for :page_title, 'About Page - High Voltage'
+
+.row
+  .col-md-12.text-center
+    %h1
+      About Page Here

--- a/app/views/pages/home.haml
+++ b/app/views/pages/home.haml
@@ -1,0 +1,6 @@
+- content_for :page_title, 'Home Page - High Voltage'
+
+.row
+  .col-md-12.text-center
+    %h1
+      Home Static Page Here

--- a/app/views/pages/modal.haml
+++ b/app/views/pages/modal.haml
@@ -1,0 +1,10 @@
+.row
+  .col-md-12.text-center
+    = content_tag :a, "Modal button",
+      href: "#modal",
+      class: 'btn btn-primary btn-outline',
+      data: { toggle: 'modal' }
+    = modal_dialog id: "modal",
+     header: { show_close: true, dismiss: 'modal', title: 'Modal title' },
+     body:   { content: 'Modal Dialog with helpers' },
+     footer: { content: content_tag(:button, 'Save', class: 'btn') }

--- a/config/initializers/high_voltage.rb
+++ b/config/initializers/high_voltage.rb
@@ -1,0 +1,4 @@
+HighVoltage.configure do |config|
+  config.home_page = 'home'
+  config.route_drawer = HighVoltage::RouteDrawers::Root
+end


### PR DESCRIPTION
HighVoltage::RouteDrawers::Root -> require us to use `.html*`
but if we use `haml` we can just have files like: `xxx.haml`
in this case the url will not work because the constraint will fail,
waiting for this issue: 